### PR TITLE
Fixing typings declaration and add example in typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,12 @@
       "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.11.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "canvas": "*"
   },
   "devDependencies": {
+    "@types/node": "^14.11.8",
     "jsdoc": "^3.6.5",
     "jsdoc-skyceil": "^1.0.5",
     "typescript": "^4.0.2"
@@ -39,5 +40,6 @@
   "directories": {
     "doc": "docs",
     "example": "examples"
-  }
+  },
+  "types": "./typings/index.d.ts"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,9 @@
             "esnext.asynciterable",
             "esnext.intl",
             "esnext.symbol"
-         ],
+        ],
         "sourceMap": false,
         "skipDefaultLibCheck": true
     },
-    "include": ["index.js", "src/"]
+    "exclude": [".github/", "aseets/", "docs/", "examples/", "node_modules/"]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,25 @@
 declare module "captcha-canvas" {
     import { Image } from "canvas";
     export const version: string;
+    interface SetCaptchaOptions {
+        characters?: number;
+        text?: string;
+        color?: string;
+        font?: string;
+        size?: number;
+        opacity?: number;
+    }
+    interface SetTraceOptions {
+        size?: number;
+        color?: string;
+        opacity?: number;
+    }
+    interface SetDecoyOptions {
+        color?: string;
+        opacity?: number;
+        font?: string;
+        size?: number;
+    }
 
     /**
      * Initatiates the creation of captcha image generation.
@@ -53,24 +72,5 @@ declare module "captcha-canvas" {
          * @description It do not use setBackground method value for background image. If you want to set background and also use generateSync method then use background option in genrateSync method.
          */
         public generateSync(options?: {background?: Image}): Buffer;
-    }
-    interface SetCaptchaOptions {
-        characters?: number;
-        text?: string;
-        color?: string;
-        font?: string;
-        size?: number;
-        opacity?: number;
-    }
-    interface SetTraceOptions {
-        size?: number;
-        color?: string;
-        opacity?: number;
-    }
-    interface SetDecoyOptions {
-        color?: string;
-        opacity?: number;
-        font?: string;
-        size?: number;
     }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,10 @@
-import { Image } from "canvas";
-
 declare module "captcha-canvas" {
+    import { Image } from "canvas";
     export const version: string;
+
+    /**
+     * Initatiates the creation of captcha image generation.
+     */
     export class CaptchaGenerator {
         constructor(options?: {height?: number, width?: number})
         public height: number;
@@ -10,12 +13,45 @@ declare module "captcha-canvas" {
         public trace: SetTraceOptions;
         public decoy: SetDecoyOptions;
 
-        public setBackgroud(image?: string);
-        public setDecoy(SetDecoyOptions);
-        public setTrace(SetTraceOptions);
-        public setCaptcha(SetCaptchaOptions);
-        public setDimension(height?: number, width?: number);
+        /**
+         * Get the text of captcha.
+         */
+        public text: string;
+
+        /**
+         * Set background for captcha image.
+         * @param image Buffer/url/path of image.
+         */
+        public setBackgroud(image: Buffer | string): CaptchaGenerator;
+        /**
+         * Change decoy options
+         * @param options Decoy characters customisation options
+         */
+        public setDecoy(options: SetDecoyOptions): CaptchaGenerator;
+        /**
+         * Change trace creation options.
+         * @param options Trace Line appearance options.
+         */
+        public setTrace(options: SetTraceOptions): CaptchaGenerator;
+        /**
+         * Change captcha text options
+         * @param options Captcha appearance options.
+         */
+        public setCaptcha(options: SetCaptchaOptions): CaptchaGenerator;
+        /**
+         * set dimension for your captcha image
+         * @param height Height of captcha image.
+         * @param width Width of captcha image.
+         */
+        public setDimension(height: number, width: number): CaptchaGenerator;
+        /**
+         * Method which returns image buffer
+         */
         public generate(): Promise<Buffer>;
+        /**
+         * Non asynchronous method to generate captcha image.
+         * @description It do not use setBackground method value for background image. If you want to set background and also use generateSync method then use background option in genrateSync method.
+         */
         public generateSync(options?: {background?: Image}): Buffer;
     }
     interface SetCaptchaOptions {

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,13 +1,15 @@
+/* eslint no-console: "off" */
+/* tslint:disable:no-reference */
 /// <reference path="index.d.ts" />
 
-import { CaptchaGenerator } from 'captcha-canvas';
+import { CaptchaGenerator } from "captcha-canvas";
 
 /**
  * This code from documentation, for typing check.
  */
 const captcha = new CaptchaGenerator()
   .setDimension(150, 450)
-  .setCaptcha({ text: 'CUSTOM05', size: 60, color: 'deeppink' })
+  .setCaptcha({ text: "CUSTOM05", size: 60, color: "deeppink" })
   .setDecoy({ opacity: 0.5 });
 
 // Get captcha text
@@ -17,5 +19,4 @@ console.log(captcha.text);
 console.log(captcha.generateSync());
 
 // For some reason, you'll want to generate asynchronously
-captcha.generate()
-  .then(buffer => console.log(buffer));
+captcha.generate().then(buffer => console.log(buffer));

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -19,4 +19,4 @@ console.log(captcha.text);
 console.log(captcha.generateSync());
 
 // For some reason, you'll want to generate asynchronously
-captcha.generate().then(buffer => console.log(buffer));
+captcha.generate().then((buffer) => console.log(buffer));

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,0 +1,21 @@
+/// <reference path="index.d.ts" />
+
+import { CaptchaGenerator } from 'captcha-canvas';
+
+/**
+ * This code from documentation, for typing check.
+ */
+const captcha = new CaptchaGenerator()
+  .setDimension(150, 450)
+  .setCaptcha({ text: 'CUSTOM05', size: 60, color: 'deeppink' })
+  .setDecoy({ opacity: 0.5 });
+
+// Get captcha text
+console.log(captcha.text);
+
+// For some reason, you'll want to generate synchronously
+console.log(captcha.generateSync());
+
+// For some reason, you'll want to generate asynchronously
+captcha.generate()
+  .then(buffer => console.log(buffer));


### PR DESCRIPTION
I was make a bot Discord using TypeScript language, and this typings for package didn't recognize in my Text Editor (i using Visual Studio Code). So, I tried to help fix this package by fixing the existing typing so that a Text Editor like Visual Studio Code can recognize this package well.