### PR TITLE
Bump skia-canvas from ^1.0.0 to ^1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "example": "examples"
   },
   "dependencies": {
-    "skia-canvas": "^1.0.0"
+    "skia-canvas": "^1.0.2"
   }
 }


### PR DESCRIPTION
This aims to fix #64 by updating the skia-canvas version from ^1.0.0 to ^1.0.2